### PR TITLE
fix: remove included packages from poetry config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 description = ""
 authors = ["David Winter <david.winter@dxw.com>"]
 readme = "README.md"
-packages = [{include = "academies_database_migration"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
Remove the redundant reference to the old python package which no longer exists. This was breaking the bootstrapping of the project when poetry attempts to install dependencies.