### PR TITLE
feat: add SQL views reporting usage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,11 @@ jobs:
         env:
           DATABASE_STRUCTURE_CONTENTS: ${{secrets.DATABASE_STRUCTURE_CONTENTS}}
 
+      - run: 'echo "${REPORTING_VIEWS_DEPENDENCIES_CONTENTS}" > reporting_views_dependencies.csv'
+        shell: bash
+        env:
+          REPORTING_VIEWS_DEPENDENCIES_CONTENTS: ${{secrets.REPORTING_VIEWS_DEPENDENCIES_CONTENTS}}
+
       - run: ./scripts/build
 
       - uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ services-repos/*/
 *.ipynb
 *.DS_Store
 nginx_auth.txt
+__pycache__

--- a/usage_reports.py
+++ b/usage_reports.py
@@ -1,0 +1,7 @@
+import pandas as pd
+
+df = pd.read_csv('reporting_views_dependencies.csv')
+
+new_df = df.pivot_table(index=['schema', 'table'], columns='view', aggfunc=lambda x: 1)
+
+reports_usage = new_df.reset_index()


### PR DESCRIPTION
Usage data from the SQL views within the `reports` schema are now included.

Extra row colouring is now in place to help highlight:

- tables that appear to be unused are faded grey
- tables that are used by only one item (be it a service or a report) are in green
- tables that are used by more than one item, but of the same type (services or report) are in yellow
- tables used by more than one item across elements (services and reports) are in orange